### PR TITLE
bugfix: Vise info-beskjed hvis varsel er maskert

### DIFF
--- a/src/components/tidligereVarsler/TidligereVarsler.jsx
+++ b/src/components/tidligereVarsler/TidligereVarsler.jsx
@@ -26,7 +26,7 @@ const VarslingerPage = () => {
       (filterType === "ALLE" || varsel.type === filterType) &&
       (varsel.tekst === null || varsel.tekst.toLowerCase().includes(filterSok))
   );
-  const hasMaskedVarsel = varsler && varsler.some((varsel) => varsel.tekst === "");
+  const hasMaskedVarsel = varsler && varsler.some((varsel) => varsel.isMasked);
 
   setLocaleDate();
   return (


### PR DESCRIPTION
Leser gjennom litt kode for å skjønne frontend, og så at beskjed om at varsel er maskert ikke dukka opp. Tror dette skal være en løsning? 😅 

![Screenshot 2023-03-03 at 10 04 40](https://user-images.githubusercontent.com/660550/222678385-8972eb41-1a77-4e3f-bd12-82b3953190b1.png)
